### PR TITLE
Support for 1.13

### DIFF
--- a/_main.cfg
+++ b/_main.cfg
@@ -4,10 +4,6 @@
     path="data/add-ons/Danse_Macabre/translations/"
 [/textdomain]
 
-[binary_path]
-    path=data/add-ons/Danse_Macabre/
-[/binary_path]
-
 # wmllint: directory spellings English Wesnoth
 # wmllint: directory spellings undead iceball plaguebeam backstab
 # wmllint: directory spellings Merrin Boreas Oryzias mage mages
@@ -17,21 +13,28 @@
 [campaign]
     id=Danse_Macabre
     rank=400
-    icon="units/zombie_lord.png~RC(magenta>red)"
+    icon="data/add-ons/Danse_Macabre/images/units/zombie_lord.png~RC(magenta>red)"
     name= _ "Danse Macabre"
     abbrev= _ "wuriDM"
     define=DANSE_MACABRE
     first_scenario=01_beginning_of_the_tragedy
+#ifver WESNOTH_VERSION < 1.13.2
     difficulties=EASY,NORMAL,HARD
     difficulty_descriptions={MENU_IMG_TXT2 "units/undead/zombie-troll.png~RC(magenta>red)" _"Creeper" _"(Normal)"} +
-    ";*" + {MENU_IMG_TXT2 "units/undead/soulless.png~RC(magenta>red)" _"Walker" _"(Challenging)"} +
-    ";" + {MENU_IMG_TXT2 "units/undead/soulless-mounted.png~RC(magenta>red)" _"Runner" _"(Difficult)"}
+        ";*" + {MENU_IMG_TXT2 "units/undead/soulless.png~RC(magenta>red)" _"Walker" _"(Challenging)"} +
+        ";" + {MENU_IMG_TXT2 "units/undead/soulless-mounted.png~RC(magenta>red)" _"Runner" _"(Difficult)"}
+#else
+    {CAMPAIGN_DIFFICULTY EASY "units/undead/zombie-troll.png~RC(magenta>red)" _"Creeper" _"Normal"}
+    {CAMPAIGN_DIFFICULTY NORMAL "units/undead/soulless.png~RC(magenta>red)" _"Walker" _"Challenging"}
+    {CAMPAIGN_DIFFICULTY HARD "units/undead/soulless-mounted.png~RC(magenta>red)" _"Runner" _"Difficult"}
+#endif
     description=_ "Macabre is a rare zombie who has intelligence and will. What's he like? What's his purpose?
 
 " + _"Note: I recommend the 'Normal' difficulty level if you're trying this campaign for the first time.
 
-" + _"(Expert level, 12 playable scenarios. version " +"1.2a"+_")"
-    image="dm_campaign_image.png"
+" + _"(Expert level, 12 playable scenarios. version " +"1.2a"+ ")"
+
+    image="data/add-ons/Danse_Macabre/images/dm_campaign_image.png"
     extra_defines=ENABLE_DEATH_KNIGHT
 
     [about]

--- a/units/a2_Running_Corpse.cfg
+++ b/units/a2_Running_Corpse.cfg
@@ -6,7 +6,6 @@
     id=Running Corpse
     name= _ "Running Corpse"
     race=undead
-    ellipse="misc/ellipse"
     {TRAIT_FEARLESS_MUSTHAVE}
     hitpoints={HP}
     movement_type={MOVETYPE}

--- a/units/a3_Brain_Eater.cfg
+++ b/units/a3_Brain_Eater.cfg
@@ -5,7 +5,6 @@
     id=Brain Eater
     name= _ "Brain Eater"
     race=undead
-    ellipse="misc/ellipse"
     {TRAIT_FEARLESS_MUSTHAVE}
     hitpoints={HP}
     movement_type={MOVETYPE}

--- a/units/a4_Battalion.cfg
+++ b/units/a4_Battalion.cfg
@@ -5,7 +5,6 @@
     id=Battalion
     name= _ "Battalion"
     race=undead
-    ellipse="misc/ellipse"
     {TRAIT_FEARLESS_MUSTHAVE}
     hitpoints={HP}
     movement_type={MOVETYPE}

--- a/units/boreas_battalion.cfg
+++ b/units/boreas_battalion.cfg
@@ -5,7 +5,6 @@
     race=undead
     image="units/battalion/battalion-bat-se-3.png"
     {MAGENTA_IS_THE_TEAM_COLOR}
-    ellipse="misc/ellipse"
     {TRAIT_FEARLESS_MUSTHAVE}
     hitpoints=74
     movement_type=smallfly

--- a/units/boreas_brain.cfg
+++ b/units/boreas_brain.cfg
@@ -5,7 +5,6 @@
     race=undead
     image="units/brain/brain-bat-se-3.png"
     {MAGENTA_IS_THE_TEAM_COLOR}
-    ellipse="misc/ellipse"
     {TRAIT_FEARLESS_MUSTHAVE}
     hitpoints=54
     movement_type=smallfly

--- a/units/boreas_running.cfg
+++ b/units/boreas_running.cfg
@@ -5,7 +5,6 @@
     race=undead
     image="units/running/running-bat-se-3.png"
     {MAGENTA_IS_THE_TEAM_COLOR}
-    ellipse="misc/ellipse"
     {TRAIT_FEARLESS_MUSTHAVE}
     hitpoints=39
     movement_type=smallfly

--- a/units/boreas_soulless.cfg
+++ b/units/boreas_soulless.cfg
@@ -6,7 +6,6 @@
     race=undead
     image="units/soulless-bat-se-3.png"
     {MAGENTA_IS_THE_TEAM_COLOR}
-    ellipse="misc/ellipse"
     {TRAIT_FEARLESS_MUSTHAVE}
     hitpoints=28
     movement_type=smallfly

--- a/units/merrin_battalion.cfg
+++ b/units/merrin_battalion.cfg
@@ -6,7 +6,6 @@
     image="units/battalion/battalion.png"
     halo=halodm/dark-aura.png
     {MAGENTA_IS_THE_TEAM_COLOR}
-    ellipse="misc/ellipse"
     {TRAIT_FEARLESS_MUSTHAVE}
     hitpoints=78
     movement_type=smallfoot

--- a/units/merrin_brain.cfg
+++ b/units/merrin_brain.cfg
@@ -6,7 +6,6 @@
     image="units/brain/brain.png"
     halo=halodm/dark-aura.png
     {MAGENTA_IS_THE_TEAM_COLOR}
-    ellipse="misc/ellipse"
     {TRAIT_FEARLESS_MUSTHAVE}
     hitpoints=58
     movement_type=smallfoot

--- a/units/merrin_running.cfg
+++ b/units/merrin_running.cfg
@@ -5,7 +5,6 @@
     race=undead
     image="units/running/running.png"
     {MAGENTA_IS_THE_TEAM_COLOR}
-    ellipse="misc/ellipse"
     {TRAIT_FEARLESS_MUSTHAVE}
     hitpoints=43
     movement_type=smallfoot

--- a/units/merrin_soulless.cfg
+++ b/units/merrin_soulless.cfg
@@ -5,7 +5,6 @@
     race=undead
     image="units/undead/soulless.png"
     {MAGENTA_IS_THE_TEAM_COLOR}
-    ellipse="misc/ellipse"
     {TRAIT_FEARLESS_MUSTHAVE}
     hitpoints=28
     movement_type=smallfoot

--- a/units/zombie_leader.cfg
+++ b/units/zombie_leader.cfg
@@ -4,7 +4,6 @@
     name= _ "Zombie Leader"
     race=undead
     image="units/zombie_leader.png"
-    ellipse="misc/ellipse"
     {MAGENTA_IS_THE_TEAM_COLOR}
     {TRAIT_FEARLESS_MUSTHAVE}
     hitpoints=32

--- a/units/zombie_lord.cfg
+++ b/units/zombie_lord.cfg
@@ -4,7 +4,6 @@
     name= _ "Zombie Lord"
     race=undead
     image="units/zombie_lord.png"
-    ellipse="misc/ellipse"
     {MAGENTA_IS_THE_TEAM_COLOR}
     {TRAIT_FEARLESS_MUSTHAVE}
     hitpoints=47

--- a/units/zz_Giant_Ant.cfg
+++ b/units/zz_Giant_Ant.cfg
@@ -5,7 +5,6 @@
     name= _ "Giant Ant"
     race=monster
     image="units/monsters/ant.png"
-    ellipse="misc/ellipse"
     hitpoints=22
     movement_type=mountainfoot
     movement=4

--- a/units/zz_Hound.cfg
+++ b/units/zz_Hound.cfg
@@ -5,7 +5,6 @@
     name= _ "Hound"
     race=monster
     image="units/monsters/hound.png"
-    ellipse="misc/ellipse"
     hitpoints=22
     movement_type=orcishfoot
     movement=7

--- a/units/zzzVampire.cfg
+++ b/units/zzzVampire.cfg
@@ -5,7 +5,6 @@
     name= _ "Vampire"
     race=undead
     image="units/vampire/elder_vampire.png"
-    ellipse="misc/ellipse"
     {MAGENTA_IS_THE_TEAM_COLOR}
     hitpoints=80
     movement_type=smallfly

--- a/units/zzzVampire_sleeping.cfg
+++ b/units/zzzVampire_sleeping.cfg
@@ -5,7 +5,6 @@
     name= _ "Sleeping Vampire"
     race=undead
     image="units/vampire/sleeping.png"
-    ellipse="misc/ellipse"
     {MAGENTA_IS_THE_TEAM_COLOR}
     hitpoints=80
     movement_type=smallfly


### PR DESCRIPTION
removed need to define the binary path outside of the ifdef
removed ellipses (not needed by default anymore since 1.12)
wmlindet changed the formating a bit too.

What I noticed too and didn't change:
The Ghast uses the same id than the mainline one, which drops a warning on stderr.