### PR TITLE
rewrote zombie files

### DIFF
--- a/units/a2_Running_Corpse.cfg
+++ b/units/a2_Running_Corpse.cfg
@@ -1,15 +1,79 @@
 #textdomain wesnoth-Danse_Macabre
 
+# Variant HP, MP, and MP types for the Running Corpse
+#define UNIT_BODY_RUNNING_CORPSE_STATS MOVETYPE_ID MOVES_NUMBER HP_AMOUNT
+    hitpoints={HP_AMOUNT}
+    movement_type={MOVETYPE_ID}
+    movement={MOVES_NUMBER}
+#enddef
+
+# The death animation is different compared to mainline
+#define UNIT_BODY_RUNNING_CORPSE_DEATH BASE_NAME
+    [death]
+        start_time=0
+        [frame]
+            image="units/running/{BASE_NAME}-die-[1~2].png:150"
+        [/frame]
+        [frame]
+            image="units/undead/{BASE_NAME}-die-[3~4].png:150"
+        [/frame]
+        [frame]
+            image="units/undead/soulless-die-[5~10].png:150"
+        [/frame]
+    [/death]
+#enddef
+
+# This is the same like in mainline - without dead animation, because drake/gryphons use a different one
+#define UNIT_BODY_RUNNING_CORPSE_ANIMATIONS BASE_NAME
+    image="units/running/{BASE_NAME}.png"
+    {DEFENSE_ANIM "units/running/{BASE_NAME}-defend.png" "units/running/{BASE_NAME}.png" {SOUND_LIST:ZOMBIE_HIT} }
+    [attack_anim]
+        [filter_attack]
+            name=touch
+        [/filter_attack]
+        direction=s
+        start_time=-200
+        [frame]
+            image="units/running/{BASE_NAME}-attack-s.png:400"
+            sound=zombie-attack.wav
+        [/frame]
+    [/attack_anim]
+    [attack_anim]
+        [filter_attack]
+            name=touch
+        [/filter_attack]
+        direction=n
+        start_time=-200
+        [frame]
+            image="units/running/{BASE_NAME}-attack-n.png:400"
+            sound=zombie-attack.wav
+        [/frame]
+    [/attack_anim]
+    [attack_anim]
+        [filter_attack]
+            name=touch
+        [/filter_attack]
+        direction=se,sw,ne,nw
+        start_time=-200
+        [frame]
+            image="units/running/{BASE_NAME}-attack.png:400"
+            sound=zombie-attack.wav
+        [/frame]
+    [/attack_anim]
+#enddef
+
+# both macros together are like the mainline one
+#define UNIT_BODY_RUNNING_CORPSE_GRAPHICS BASE_NAME
+    {UNIT_BODY_RUNNING_CORPSE_ANIMATIONS {BASE_NAME}}
+    {UNIT_BODY_RUNNING_CORPSE_DEATH {BASE_NAME}}
+#enddef
+
 [unit_type]
-    #macro to define most of the non-graphical part of Walking Corpse
-#define UNIT_BODY_RUNNINGCORPSE_STATS MOVETYPE MOVES HP
     id=Running Corpse
     name= _ "Running Corpse"
+    profile=portraits/undead/soulless.png
     race=undead
     {TRAIT_FEARLESS_MUSTHAVE}
-    hitpoints={HP}
-    movement_type={MOVETYPE}
-    movement={MOVES}
     experience=80
     level=2
     alignment=chaotic
@@ -17,9 +81,13 @@
     cost=23
     usage=fighter
     description= _ "Most of corpses animated by Necromancer are slow of movement. But only a few corpses, who have escaped death for a long time and chanced on many meals, regains freshness and can run again. It is difficult to escape from them, so still many living beings will become food for them."+{SPECIAL_NOTES}+{SPECIAL_NOTES_PLAGUE}
-    [resistance]
-        arcane=140
-    [/resistance]
+    die_sound={SOUND_LIST:ZOMBIE_HIT}
+    {MAGENTA_IS_THE_TEAM_COLOR}
+    [advancefrom]
+        unit=Soulless
+        experience=35
+    [/advancefrom]
+
     [attack]
         name=touch
         description={STR_TOUCH}
@@ -32,289 +100,177 @@
             {WEAPON_SPECIAL_PLAGUE}
         [/specials]
     [/attack]
-#enddef
-    #macro to define most of the graphical part of Walking Corpse
-#define UNIT_BODY_RUNNINGCORPSE_GRAPHICS_NO_DEATH_ANIM BASE_IMAGESTEM
-    image="units/running/{BASE_IMAGESTEM}.png"
-    {MAGENTA_IS_THE_TEAM_COLOR}
-    die_sound={SOUND_LIST:ZOMBIE_HIT}
-    {DEFENSE_ANIM "units/running/{BASE_IMAGESTEM}-defend.png" "units/running/{BASE_IMAGESTEM}.png" {SOUND_LIST:ZOMBIE_HIT} }
-    [death]
-        start_time=0
-        [frame]
-            duration=150
-            image="units/running/running-die-4.png"
-        [/frame]
-        [frame]
-            duration=150
-            image="units/running/running-die-5.png"
-        [/frame]
-        [frame]
-            duration=150
-            image="units/running/running-die-6.png"
-        [/frame]
-        [frame]
-            duration=150
-            image="units/running/running-die-7.png"
-        [/frame]
-        [frame]
-            duration=150
-            image="units/running/running-die-8.png"
-        [/frame]
-        [frame]
-            duration=150
-            image="units/running/running-die-9.png"
-        [/frame]
-        [frame]
-            duration=150
-            image="units/running/running-die-10.png"
-        [/frame]
-    [/death]
-    [attack_anim]
-        [filter_attack]
-            name=touch
-        [/filter_attack]
-        direction=s
-        [frame]
-            begin=-200
-            end=200
-            image="units/running/{BASE_IMAGESTEM}-attack-s.png"
-            sound=zombie-attack.wav
-        [/frame]
-    [/attack_anim]
-    [attack_anim]
-        [filter_attack]
-            name=touch
-        [/filter_attack]
-        direction=n
-        [frame]
-            begin=-200
-            end=200
-            image="units/running/{BASE_IMAGESTEM}-attack-n.png"
-            sound=zombie-attack.wav
-        [/frame]
-    [/attack_anim]
-    [attack_anim]
-        [filter_attack]
-            name=touch
-        [/filter_attack]
-        direction=se,sw,ne,nw
-        [frame]
-            begin=-200
-            end=200
-            image="units/running/{BASE_IMAGESTEM}-attack.png"
-            sound=zombie-attack.wav
-        [/frame]
-    [/attack_anim]
-#enddef
-#define UNIT_BODY_RUNNINGCORPSE_GRAPHICS BASE_IMAGESTEM
-    image="units/running/{BASE_IMAGESTEM}.png"
-    {MAGENTA_IS_THE_TEAM_COLOR}
-    die_sound={SOUND_LIST:ZOMBIE_HIT}
-    {DEFENSE_ANIM "units/running/{BASE_IMAGESTEM}-defend.png" "units/running/{BASE_IMAGESTEM}.png" {SOUND_LIST:ZOMBIE_HIT} }
-    [death]
-        start_time=0
-        [frame]
-            duration=150
-            image="units/running/{BASE_IMAGESTEM}-die-1.png"
-        [/frame]
-        [frame]
-            duration=150
-            image="units/running/{BASE_IMAGESTEM}-die-2.png"
-        [/frame]
-        [frame]
-            duration=150
-            image="units/running/{BASE_IMAGESTEM}-die-3.png"
-        [/frame]
-        [frame]
-            duration=150
-            image="units/running/{BASE_IMAGESTEM}-die-4.png"
-        [/frame]
-        [frame]
-            duration=150
-            image="units/running/running-die-5.png"
-        [/frame]
-        [frame]
-            duration=150
-            image="units/running/running-die-6.png"
-        [/frame]
-        [frame]
-            duration=150
-            image="units/running/running-die-7.png"
-        [/frame]
-        [frame]
-            duration=150
-            image="units/running/running-die-8.png"
-        [/frame]
-        [frame]
-            duration=150
-            image="units/running/running-die-9.png"
-        [/frame]
-        [frame]
-            duration=150
-            image="units/running/running-die-10.png"
-        [/frame]
-    [/death]
-    [attack_anim]
-        [filter_attack]
-            name=touch
-        [/filter_attack]
-        direction=s
-        [frame]
-            begin=-200
-            end=200
-            image="units/running/{BASE_IMAGESTEM}-attack-s.png"
-            sound=zombie-attack.wav
-        [/frame]
-    [/attack_anim]
-    [attack_anim]
-        [filter_attack]
-            name=touch
-        [/filter_attack]
-        direction=n
-        [frame]
-            begin=-200
-            end=200
-            image="units/running/{BASE_IMAGESTEM}-attack-n.png"
-            sound=zombie-attack.wav
-        [/frame]
-    [/attack_anim]
-    [attack_anim]
-        [filter_attack]
-            name=touch
-        [/filter_attack]
-        direction=se,sw,ne,nw
-        [frame]
-            begin=-200
-            end=200
-            image="units/running/{BASE_IMAGESTEM}-attack.png"
-            sound=zombie-attack.wav
-        [/frame]
-    [/attack_anim]
-#enddef
-    {UNIT_BODY_RUNNINGCORPSE_STATS smallfoot 5 43}
-    {UNIT_BODY_RUNNINGCORPSE_GRAPHICS running}
+
+    [resistance]
+        arcane=140
+    [/resistance]
     [movement_costs]
         deep_water=4
     [/movement_costs]
     [defense]
         deep_water=90
     [/defense]
-    [advancefrom]
-        unit=Soulless
-        experience=35
-    [/advancefrom]
+
+    {UNIT_BODY_RUNNING_CORPSE_STATS    smallfoot 5 43}
+    {UNIT_BODY_RUNNING_CORPSE_GRAPHICS running}
+
     #textdomain wesnoth-units
     [variation]
         variation_id=drake
         variation_name= _ "wc_variation^Drake"
-        {UNIT_BODY_RUNNINGCORPSE_STATS drakefoot 5 51}
-        {UNIT_BODY_RUNNINGCORPSE_GRAPHICS_NO_DEATH_ANIM running-drake}
+        inherit=yes
+        profile=unit_image
+        {UNIT_BODY_RUNNING_CORPSE_STATS      drakefoot 5 51}
+        {UNIT_BODY_RUNNING_CORPSE_ANIMATIONS running-drake}
         [movement_costs]
-            deep_water=4
+            unwalkable=4
         [/movement_costs]
         [defense]
-            deep_water=90
+            unwalkable=90
         [/defense]
+        [death]
+            start_time=0
+            [frame]
+                image="units/running/running-drake-die-[1~3].png:150"
+            [/frame]
+            [frame]
+                image="units/running/running-drake-die-3.png:600"
+                alpha=1~0
+            [/frame]
+        [/death]
     [/variation]
+
     [variation]
         variation_id=dwarf
         variation_name= _ "wc_variation^Dwarf"
-        {UNIT_BODY_RUNNINGCORPSE_STATS dwarvishfoot 4 48}
-        {UNIT_BODY_RUNNINGCORPSE_GRAPHICS running-dwarf}
-        [movement_costs]
-            deep_water=3
-        [/movement_costs]
-        [defense]
-            deep_water=90
-        [/defense]
+        inherit=yes
+        profile=unit_image
+        {UNIT_BODY_RUNNING_CORPSE_STATS    dwarvishfoot 4 48}
+        {UNIT_BODY_RUNNING_CORPSE_GRAPHICS running-dwarf}
     [/variation]
+
+    #[variation]
+    #    variation_id=goblin
+    #    variation_name= _ "wc_variation^Goblin"
+    #    inherit=yes
+    #    profile=unit_image
+    #    {UNIT_BODY_RUNNING_CORPSE_STATS    smallfoot X XX}
+    #    {UNIT_BODY_RUNNING_CORPSE_GRAPHICS soulless-goblin}
+    #[/variation]
+
     [variation]
         variation_id=mounted
         variation_name= _ "wc_variation^Mounted"
-        {UNIT_BODY_RUNNINGCORPSE_STATS mounted 6 48}
-        {UNIT_BODY_RUNNINGCORPSE_GRAPHICS running-mounted}
-        [movement_costs]
-            deep_water=4
-        [/movement_costs]
-        [defense]
-            deep_water=90
-        [/defense]
+        inherit=yes
+        # Default portrait is fine for Mounted
+        {UNIT_BODY_RUNNING_CORPSE_STATS    mounted 6 48}
+        {UNIT_BODY_RUNNING_CORPSE_GRAPHICS running-mounted}
     [/variation]
+
     [variation]
         variation_id=gryphon
         variation_name= _ "wc_variation^Gryphon"
-        {UNIT_BODY_RUNNINGCORPSE_STATS fly 6 48}
-        {UNIT_BODY_RUNNINGCORPSE_GRAPHICS running-drake}
+        inherit=yes
+        profile=unit_image
+        {UNIT_BODY_RUNNING_CORPSE_STATS      fly 6 48}
+        {UNIT_BODY_RUNNING_CORPSE_ANIMATIONS running-drake}
+        [movement_costs]
+            deep_water=1
+        [/movement_costs]
         [defense]
             mountains=40
+            deep_water=50
         [/defense]
+        [death]
+            start_time=0
+            [frame]
+                image="units/running/running-drake-die-[1~3].png:150"
+            [/frame]
+            [frame]
+                image="units/running/running-drake-die-3.png:600"
+                alpha=1~0
+            [/frame]
+        [/death]
     [/variation]
+
     [variation]
         variation_id=saurian
         variation_name= _ "wc_variation^Saurian"
-        {UNIT_BODY_RUNNINGCORPSE_STATS lizard 5 40}
-        {UNIT_BODY_RUNNINGCORPSE_GRAPHICS running-saurian}
-        [movement_costs]
-            deep_water=4
-        [/movement_costs]
-        [defense]
-            deep_water=90
-        [/defense]
+        inherit=yes
+        profile=unit_image
+        {UNIT_BODY_RUNNING_CORPSE_STATS    lizard 5 40}
+        {UNIT_BODY_RUNNING_CORPSE_GRAPHICS running-saurian}
     [/variation]
+
     [variation]
         variation_id=swimmer
         variation_name= _ "wc_variation^Swimmer"
-        {UNIT_BODY_RUNNINGCORPSE_STATS swimmer 5 43}
-        {UNIT_BODY_RUNNINGCORPSE_GRAPHICS running-swimmer}
+        inherit=yes
+        profile=unit_image
+        {UNIT_BODY_RUNNING_CORPSE_STATS    swimmer 5 43}
+        {UNIT_BODY_RUNNING_CORPSE_GRAPHICS running-swimmer}
         [movement_costs]
             forest=4
             hills=4
+            deep_water=1
         [/movement_costs]
+        [defense]
+            deep_water=50
+        [/defense]
     [/variation]
+
     [variation]
         variation_id=troll
         variation_name= _ "wc_variation^Troll"
-        {UNIT_BODY_RUNNINGCORPSE_STATS largefoot 5 48}
-        {UNIT_BODY_RUNNINGCORPSE_GRAPHICS running-troll}
-        [movement_costs]
-            deep_water=4
-        [/movement_costs]
-        [defense]
-            deep_water=90
-        [/defense]
+        inherit=yes
+        profile=unit_image
+        {UNIT_BODY_RUNNING_CORPSE_STATS    largefoot 5 48}
+        {UNIT_BODY_RUNNING_CORPSE_GRAPHICS running-troll}
     [/variation]
+
     [variation]
         variation_id=wose
         variation_name= _ "wc_variation^Wose"
-        {UNIT_BODY_RUNNINGCORPSE_STATS treefolk 4 55}
-        {UNIT_BODY_RUNNINGCORPSE_GRAPHICS running-wose}
-        [movement_costs]
-            deep_water=3
-        [/movement_costs]
-        [defense]
-            deep_water=90
-        [/defense]
+        inherit=yes
+        profile=unit_image
+        {UNIT_BODY_RUNNING_CORPSE_STATS    treefolk 4 55}
+        {UNIT_BODY_RUNNING_CORPSE_GRAPHICS running-wose}
     [/variation]
+
+    #[variation]
+    #    variation_id=wolf
+    #    variation_name= _ "wc_variation^Wolf"
+    #    inherit=yes
+    #    profile=unit_image
+    #    {UNIT_BODY_RUNNING_CORPSE_STATS orcishfoot X XX}
+    #    {UNIT_BODY_RUNNING_CORPSE_GRAPHICS soulless-wolf}
+    #    [defense]
+    #        village=50
+    #    [/defense]
+    #[/variation]
+
     [variation]
         variation_id=bat
         variation_name= _ "wc_variation^Bat"
-        inherit=no
-        {UNIT_BODY_RUNNINGCORPSE_STATS fly 6 39}
+        inherit=yes
+        profile=unit_image
+        {UNIT_BODY_RUNNING_CORPSE_STATS fly 6 39}
+        {UNIT_BODY_RUNNING_CORPSE_DEATH running-bat}
+        image="units/running/running-bat-se-3.png"
+        die_sound="bat-flapping.wav"
         [movement_costs]
             cave=1
             fungus=1
+            deep_water=1
         [/movement_costs]
         [defense]
             cave=50
             fungus=50
+            deep_water=50
         [/defense]
         [resistance]
             cold=70
         [/resistance]
-        {MAGENTA_IS_THE_TEAM_COLOR}
-        image="units/running/running-bat-se-3.png"
-        die_sound="bat-flapping.wav"
         [defend]
             direction=s,sw,se
             [if]
@@ -323,32 +279,9 @@
             [/if]
             start_time=-126
             [frame]
-                duration=1
-                image="units/running/running-bat-se-3.png"
+                image="units/running/running-bat-se-[3,4,3].png:[1,250,1]"
             [/frame]
-            [frame]
-                duration=100
-                image="units/running/running-bat-se-4.png"
-            [/frame]
-            [if]
-                hits=hit
-                [frame]
-                    duration=150
-                    image="units/running/running-bat-se-4.png"
-                    sound={SOUND_LIST:ZOMBIE_WEAK_HIT}
-                [/frame]
-            [/if]
-            [else]
-                hits=miss,kill
-                [frame]
-                    duration=150
-                    image="units/running/running-bat-se-4.png"
-                [/frame]
-            [/else]
-            [frame]
-                duration=1
-                image="units/running/running-bat-se-3.png"
-            [/frame]
+            {SOUND:HIT {SOUND_LIST:ZOMBIE_WEAK_HIT} -25}
         [/defend]
         [defend]
             direction=n,nw,ne
@@ -358,103 +291,22 @@
             [/if]
             start_time=-126
             [frame]
-                duration=1
-                image="units/running/running-bat-ne-3.png"
+                image="units/running/running-bat-ne-[3,4,3].png:[1,250,1]"
             [/frame]
-            [frame]
-                duration=100
-                image="units/running/running-bat-ne-4.png"
-            [/frame]
-            [if]
-                hits=hit
-                [frame]
-                    duration=150
-                    image="units/running/running-bat-ne-4.png"
-                    sound={SOUND_LIST:ZOMBIE_WEAK_HIT}
-                [/frame]
-            [/if]
-            [else]
-                hits=miss,kill
-                [frame]
-                    duration=150
-                    image="units/running/running-bat-ne-4.png"
-                [/frame]
-            [/else]
-            [frame]
-                duration=1
-                image="units/running/running-bat-ne-3.png"
-            [/frame]
+            {SOUND:HIT {SOUND_LIST:ZOMBIE_WEAK_HIT} -25}
         [/defend]
         [standing_anim]
             direction=s,se,sw
             start_time=0
             [frame]
-                duration=50
-                image="units/running/running-bat-se-3.png"
-            [/frame]
-            [frame]
-                duration=60
-                image="units/running/running-bat-se-2.png"
-            [/frame]
-            [frame]
-                duration=80
-                image="units/running/running-bat-se-1.png"
-            [/frame]
-            [frame]
-                duration=60
-                image="units/running/running-bat-se-2.png"
-            [/frame]
-            [frame]
-                duration=50
-                image="units/running/running-bat-se-3.png"
-            [/frame]
-            [frame]
-                duration=60
-                image="units/running/running-bat-se-4.png"
-            [/frame]
-            [frame]
-                duration=80
-                image="units/running/running-bat-se-5.png"
-            [/frame]
-            [frame]
-                duration=60
-                image="units/running/running-bat-se-4.png"
+                image="units/running/running-bat-se-[3~1,2~5,4].png:[50,60,80,60,50,60,80,60]"
             [/frame]
         [/standing_anim]
         [standing_anim]
             direction=n,ne,nw
             start_time=0
             [frame]
-                duration=50
-                image="units/running/running-bat-ne-3.png"
-            [/frame]
-            [frame]
-                duration=60
-                image="units/running/running-bat-ne-2.png"
-            [/frame]
-            [frame]
-                duration=80
-                image="units/running/running-bat-ne-1.png"
-            [/frame]
-            [frame]
-                duration=60
-                image="units/running/running-bat-ne-2.png"
-            [/frame]
-            [frame]
-                duration=50
-                image="units/running/running-bat-ne-3.png"
-            [/frame]
-            [frame]
-                duration=60
-                image="units/running/running-bat-ne-4.png"
-            [/frame]
-            [frame]
-                duration=80
-                image="units/running/running-bat-ne-5.png"
-            [/frame]
-            [frame]
-                duration=60
-                image="units/running/running-bat-ne-4.png"
+                image="units/running/running-bat-ne-[3~1,2~5,4].png:[50,60,80,60,50,60,80,60]"
             [/frame]
         [/standing_anim]
 
@@ -466,42 +318,21 @@
             offset=0.0~0.9:200,0.9~0.0:160
             start_time=-200
             [frame]
-                duration=30
-                image="units/running/running-bat-se-3.png"
+                image="units/running/running-bat-se-[3,2].png:30"
             [/frame]
             [frame]
-                duration=30
-                image="units/running/running-bat-se-2.png"
-            [/frame]
-            [frame]
-                duration=30
-                image="units/running/running-bat-se-1.png"
+                image="units/running/running-bat-se-1.png:30"
                 sound=bat-flapping.wav
             [/frame]
             [frame]
-                duration=30
-                image="units/running/running-bat-se-2.png"
+                image="units/running/running-bat-se-[2,3].png:30"
             [/frame]
             [frame]
-                duration=30
-                image="units/running/running-bat-se-3.png"
-            [/frame]
-            [frame]
-                duration=70
-                image="units/running/running-bat-se-4.png"
+                image="units/running/running-bat-se-4.png:70"
                 sound=zombie-attack.wav
             [/frame]
             [frame]
-                duration=50
-                image="units/running/running-bat-se-3.png"
-            [/frame]
-            [frame]
-                duration=50
-                image="units/running/running-bat-se-2.png"
-            [/frame]
-            [frame]
-                duration=40
-                image="units/running/running-bat-se-3.png"
+                image="units/running/running-bat-se-[3,2,3].png:[50*2,40]"
             [/frame]
         [/attack_anim]
 
@@ -513,87 +344,27 @@
             offset=0.0~0.9:200,0.9~0.0:160
             start_time=-200
             [frame]
-                duration=30
-                image="units/running/running-bat-ne-3.png"
+                image="units/running/running-bat-ne-[3,2].png:30"
             [/frame]
             [frame]
-                duration=30
-                image="units/running/running-bat-ne-2.png"
-            [/frame]
-            [frame]
-                duration=30
-                image="units/running/running-bat-ne-1.png"
+                image="units/running/running-bat-ne-1.png:30"
                 sound=bat-flapping.wav
             [/frame]
             [frame]
-                duration=30
-                image="units/running/running-bat-ne-2.png"
+                image="units/running/running-bat-ne-[2,3].png:30"
             [/frame]
             [frame]
-                duration=30
-                image="units/running/running-bat-ne-3.png"
-            [/frame]
-            [frame]
-                duration=70
-                image="units/running/running-bat-ne-4.png"
+                image="units/running/running-bat-ne-4.png:70"
                 sound=zombie-attack.wav
             [/frame]
             [frame]
-                duration=50
-                image="units/running/running-bat-ne-3.png"
-            [/frame]
-            [frame]
-                duration=50
-                image="units/running/running-bat-ne-2.png"
-            [/frame]
-            [frame]
-                duration=40
-                image="units/running/running-bat-ne-3.png"
+                image="units/running/running-bat-ne-[3,2,3].png:[50*2,40]"
             [/frame]
         [/attack_anim]
-        [death]
-            start_time=0
-            [frame]
-                duration=150
-                image="units/running/running-bat-die-1.png"
-            [/frame]
-            [frame]
-                duration=150
-                image="units/running/running-bat-die-2.png"
-            [/frame]
-            [frame]
-                duration=150
-                image="units/running/running-bat-die-3.png"
-            [/frame]
-            [frame]
-                duration=150
-                image="units/running/running-bat-die-4.png"
-            [/frame]
-            [frame]
-                duration=150
-                image="units/running/running-die-5.png"
-            [/frame]
-            [frame]
-                duration=150
-                image="units/running/running-die-6.png"
-            [/frame]
-            [frame]
-                duration=150
-                image="units/running/running-die-7.png"
-            [/frame]
-            [frame]
-                duration=150
-                image="units/running/running-die-8.png"
-            [/frame]
-            [frame]
-                duration=150
-                image="units/running/running-die-9.png"
-            [/frame]
-            [frame]
-                duration=150
-                image="units/running/running-die-10.png"
-            [/frame]
-        [/death]
     [/variation]
-    #textdomain wesnoth-Danse_Macabre
 [/unit_type]
+
+#undef UNIT_BODY_RUNNING_CORPSE_STATS
+#undef UNIT_BODY_RUNNING_CORPSE_GRAPHICS
+#undef UNIT_BODY_RUNNING_CORPSE_ANIMATIONS
+#undef UNIT_BODY_RUNNING_CORPSE_DEATH

--- a/units/a3_Brain_Eater.cfg
+++ b/units/a3_Brain_Eater.cfg
@@ -1,14 +1,79 @@
 #textdomain wesnoth-Danse_Macabre
+
+# Variant HP, MP, and MP types for the Brain Eater
+#define UNIT_BODY_BRAIN_EATER_STATS MOVETYPE_ID MOVES_NUMBER HP_AMOUNT
+    hitpoints={HP_AMOUNT}
+    movement_type={MOVETYPE_ID}
+    movement={MOVES_NUMBER}
+#enddef
+
+# The death animation is different compared to mainline
+#define UNIT_BODY_BRAIN_EATER_DEATH BASE_NAME
+    [death]
+        start_time=0
+        [frame]
+            image="units/brain/{BASE_NAME}-die-[1~2].png:150"
+        [/frame]
+        [frame]
+            image="units/undead/{BASE_NAME}-die-[3~4].png:150"
+        [/frame]
+        [frame]
+            image="units/undead/soulless-die-[5~10].png:150"
+        [/frame]
+    [/death]
+#enddef
+
+# This is the same like in mainline - without dead animation, because drake/gryphons use a different one
+#define UNIT_BODY_BRAIN_EATER_ANIMATIONS BASE_NAME
+    image="units/brain/{BASE_NAME}.png"
+    {DEFENSE_ANIM "units/brain/{BASE_NAME}-defend.png" "units/brain/{BASE_NAME}.png" {SOUND_LIST:ZOMBIE_HIT} }
+    [attack_anim]
+        [filter_attack]
+            name=touch
+        [/filter_attack]
+        direction=s
+        start_time=-200
+        [frame]
+            image="units/brain/{BASE_NAME}-attack-s.png:400"
+            sound=zombie-attack.wav
+        [/frame]
+    [/attack_anim]
+    [attack_anim]
+        [filter_attack]
+            name=touch
+        [/filter_attack]
+        direction=n
+        start_time=-200
+        [frame]
+            image="units/brain/{BASE_NAME}-attack-n.png:400"
+            sound=zombie-attack.wav
+        [/frame]
+    [/attack_anim]
+    [attack_anim]
+        [filter_attack]
+            name=touch
+        [/filter_attack]
+        direction=se,sw,ne,nw
+        start_time=-200
+        [frame]
+            image="units/brain/{BASE_NAME}-attack.png:400"
+            sound=zombie-attack.wav
+        [/frame]
+    [/attack_anim]
+#enddef
+
+# both macros together are like the mainline one
+#define UNIT_BODY_BRAIN_EATER_GRAPHICS BASE_NAME
+    {UNIT_BODY_BRAIN_EATER_ANIMATIONS {BASE_NAME}}
+    {UNIT_BODY_BRAIN_EATER_DEATH {BASE_NAME}}
+#enddef
+
 [unit_type]
-    #macro to define most of the non-graphical part of Walking Corpse
-#define UNIT_BODY_BRAINEATER_STATS MOVETYPE MOVES HP
     id=Brain Eater
     name= _ "Brain Eater"
+    profile=portraits/undead/soulless.png
     race=undead
     {TRAIT_FEARLESS_MUSTHAVE}
-    hitpoints={HP}
-    movement_type={MOVETYPE}
-    movement={MOVES}
     experience=180
     level=3
     alignment=chaotic
@@ -16,9 +81,9 @@
     cost=33
     usage=fighter
     description= _ "Brain Eaters are epicurean corpses who take pleasure in eating brains. Brains become the greatest delicacies for them. Do brain lovers change into Brain Eaters, or do Brain Eaters need to eat brains? Anyway, they can run faster and attack stronger than in life. They scare even elite units."+{SPECIAL_NOTES}+{SPECIAL_NOTES_PLAGUE}
-    [resistance]
-        arcane=140
-    [/resistance]
+    die_sound={SOUND_LIST:ZOMBIE_HIT}
+    {MAGENTA_IS_THE_TEAM_COLOR}
+
     [attack]
         name=touch
         description={STR_TOUCH}
@@ -31,285 +96,177 @@
             {WEAPON_SPECIAL_PLAGUE}
         [/specials]
     [/attack]
-#enddef
-    #macro to define most of the graphical part of Walking Corpse
-#define UNIT_BODY_BRAINEATER_GRAPHICS_NO_DEATH_ANIM BASE_IMAGESTEM
-    image="units/brain/{BASE_IMAGESTEM}.png"
-    {MAGENTA_IS_THE_TEAM_COLOR}
-    die_sound={SOUND_LIST:ZOMBIE_HIT}
-    {DEFENSE_ANIM "units/brain/{BASE_IMAGESTEM}-defend.png" "units/brain/{BASE_IMAGESTEM}.png" {SOUND_LIST:ZOMBIE_HIT} }
-    [death]
-        start_time=0
-        [frame]
-            duration=150
-            image="units/brain/brain-die-4.png"
-        [/frame]
-        [frame]
-            duration=150
-            image="units/brain/brain-die-5.png"
-        [/frame]
-        [frame]
-            duration=150
-            image="units/brain/brain-die-6.png"
-        [/frame]
-        [frame]
-            duration=150
-            image="units/brain/brain-die-7.png"
-        [/frame]
-        [frame]
-            duration=150
-            image="units/brain/brain-die-8.png"
-        [/frame]
-        [frame]
-            duration=150
-            image="units/brain/brain-die-9.png"
-        [/frame]
-        [frame]
-            duration=150
-            image="units/brain/brain-die-10.png"
-        [/frame]
-    [/death]
-    [attack_anim]
-        [filter_attack]
-            name=touch
-        [/filter_attack]
-        direction=s
-        [frame]
-            begin=-200
-            end=200
-            image="units/brain/{BASE_IMAGESTEM}-attack-s.png"
-            sound=zombie-attack.wav
-        [/frame]
-    [/attack_anim]
-    [attack_anim]
-        [filter_attack]
-            name=touch
-        [/filter_attack]
-        direction=n
-        [frame]
-            begin=-200
-            end=200
-            image="units/brain/{BASE_IMAGESTEM}-attack-n.png"
-            sound=zombie-attack.wav
-        [/frame]
-    [/attack_anim]
-    [attack_anim]
-        [filter_attack]
-            name=touch
-        [/filter_attack]
-        direction=se,sw,ne,nw
-        [frame]
-            begin=-200
-            end=200
-            image="units/brain/{BASE_IMAGESTEM}-attack.png"
-            sound=zombie-attack.wav
-        [/frame]
-    [/attack_anim]
-#enddef
-#define UNIT_BODY_BRAINEATER_GRAPHICS BASE_IMAGESTEM
-    image="units/brain/{BASE_IMAGESTEM}.png"
-    {MAGENTA_IS_THE_TEAM_COLOR}
-    die_sound={SOUND_LIST:ZOMBIE_HIT}
-    {DEFENSE_ANIM "units/brain/{BASE_IMAGESTEM}-defend.png" "units/brain/{BASE_IMAGESTEM}.png" {SOUND_LIST:ZOMBIE_HIT} }
-    [death]
-        start_time=0
-        [frame]
-            duration=150
-            image="units/brain/{BASE_IMAGESTEM}-die-1.png"
-        [/frame]
-        [frame]
-            duration=150
-            image="units/brain/{BASE_IMAGESTEM}-die-2.png"
-        [/frame]
-        [frame]
-            duration=150
-            image="units/brain/{BASE_IMAGESTEM}-die-3.png"
-        [/frame]
-        [frame]
-            duration=150
-            image="units/brain/{BASE_IMAGESTEM}-die-4.png"
-        [/frame]
-        [frame]
-            duration=150
-            image="units/brain/brain-die-5.png"
-        [/frame]
-        [frame]
-            duration=150
-            image="units/brain/brain-die-6.png"
-        [/frame]
-        [frame]
-            duration=150
-            image="units/brain/brain-die-7.png"
-        [/frame]
-        [frame]
-            duration=150
-            image="units/brain/brain-die-8.png"
-        [/frame]
-        [frame]
-            duration=150
-            image="units/brain/brain-die-9.png"
-        [/frame]
-        [frame]
-            duration=150
-            image="units/brain/brain-die-10.png"
-        [/frame]
-    [/death]
-    [attack_anim]
-        [filter_attack]
-            name=touch
-        [/filter_attack]
-        direction=s
-        [frame]
-            begin=-200
-            end=200
-            image="units/brain/{BASE_IMAGESTEM}-attack-s.png"
-            sound=zombie-attack.wav
-        [/frame]
-    [/attack_anim]
-    [attack_anim]
-        [filter_attack]
-            name=touch
-        [/filter_attack]
-        direction=n
-        [frame]
-            begin=-200
-            end=200
-            image="units/brain/{BASE_IMAGESTEM}-attack-n.png"
-            sound=zombie-attack.wav
-        [/frame]
-    [/attack_anim]
-    [attack_anim]
-        [filter_attack]
-            name=touch
-        [/filter_attack]
-        direction=se,sw,ne,nw
-        [frame]
-            begin=-200
-            end=200
-            image="units/brain/{BASE_IMAGESTEM}-attack.png"
-            sound=zombie-attack.wav
-        [/frame]
-    [/attack_anim]
-#enddef
-    {UNIT_BODY_BRAINEATER_STATS smallfoot 5 58}
-    {UNIT_BODY_BRAINEATER_GRAPHICS brain}
+
+    [resistance]
+        arcane=140
+    [/resistance]
     [movement_costs]
         deep_water=4
     [/movement_costs]
     [defense]
         deep_water=90
     [/defense]
+
+    {UNIT_BODY_BRAIN_EATER_STATS    smallfoot 5 58}
+    {UNIT_BODY_BRAIN_EATER_GRAPHICS brain}
+
     #textdomain wesnoth-units
     [variation]
         variation_id=drake
         variation_name= _ "wc_variation^Drake"
-        {UNIT_BODY_BRAINEATER_STATS drakefoot 5 66}
-        {UNIT_BODY_BRAINEATER_GRAPHICS_NO_DEATH_ANIM brain-drake}
+        inherit=yes
+        profile=unit_image
+        {UNIT_BODY_BRAIN_EATER_STATS      drakefoot 5 66}
+        {UNIT_BODY_BRAIN_EATER_ANIMATIONS brain-drake}
         [movement_costs]
-            deep_water=4
+            unwalkable=4
         [/movement_costs]
         [defense]
-            deep_water=90
+            unwalkable=90
         [/defense]
+        [death]
+            start_time=0
+            [frame]
+                image="units/brain/brain-drake-die-[1~3].png:150"
+            [/frame]
+            [frame]
+                image="units/brain/brain-drake-die-3.png:600"
+                alpha=1~0
+            [/frame]
+        [/death]
     [/variation]
+
     [variation]
         variation_id=dwarf
         variation_name= _ "wc_variation^Dwarf"
-        {UNIT_BODY_BRAINEATER_STATS dwarvishfoot 4 63}
-        {UNIT_BODY_BRAINEATER_GRAPHICS brain-dwarf}
-        [movement_costs]
-            deep_water=3
-        [/movement_costs]
-        [defense]
-            deep_water=90
-        [/defense]
+        inherit=yes
+        profile=unit_image
+        {UNIT_BODY_BRAIN_EATER_STATS    dwarvishfoot 4 63}
+        {UNIT_BODY_BRAIN_EATER_GRAPHICS brain-dwarf}
     [/variation]
+
+    #[variation]
+    #    variation_id=goblin
+    #    variation_name= _ "wc_variation^Goblin"
+    #    inherit=yes
+    #    profile=unit_image
+    #    {UNIT_BODY_BRAIN_EATER_STATS    smallfoot X XX}
+    #    {UNIT_BODY_BRAIN_EATER_GRAPHICS soulless-goblin}
+    #[/variation]
+
     [variation]
         variation_id=mounted
         variation_name= _ "wc_variation^Mounted"
-        {UNIT_BODY_BRAINEATER_STATS mounted 6 63}
-        {UNIT_BODY_BRAINEATER_GRAPHICS brain-mounted}
-        [movement_costs]
-            deep_water=4
-        [/movement_costs]
-        [defense]
-            deep_water=90
-        [/defense]
+        inherit=yes
+        # Default portrait is fine for Mounted
+        {UNIT_BODY_BRAIN_EATER_STATS    mounted 6 63}
+        {UNIT_BODY_BRAIN_EATER_GRAPHICS brain-mounted}
     [/variation]
+
     [variation]
         variation_id=gryphon
         variation_name= _ "wc_variation^Gryphon"
-        {UNIT_BODY_BRAINEATER_STATS fly 6 63}
-        {UNIT_BODY_BRAINEATER_GRAPHICS brain-drake}
+        inherit=yes
+        profile=unit_image
+        {UNIT_BODY_BRAIN_EATER_STATS      fly 6 63}
+        {UNIT_BODY_BRAIN_EATER_ANIMATIONS brain-drake}
+        [movement_costs]
+            deep_water=1
+        [/movement_costs]
         [defense]
             mountains=40
+            deep_water=50
         [/defense]
+        [death]
+            start_time=0
+            [frame]
+                image="units/brain/brain-drake-die-[1~3].png:150"
+            [/frame]
+            [frame]
+                image="units/brain/brain-drake-die-3.png:600"
+                alpha=1~0
+            [/frame]
+        [/death]
     [/variation]
+
     [variation]
         variation_id=saurian
         variation_name= _ "wc_variation^Saurian"
-        {UNIT_BODY_BRAINEATER_STATS lizard 5 55}
-        {UNIT_BODY_BRAINEATER_GRAPHICS brain-saurian}
-        [movement_costs]
-            deep_water=4
-        [/movement_costs]
-        [defense]
-            deep_water=90
-        [/defense]
+        inherit=yes
+        profile=unit_image
+        {UNIT_BODY_BRAIN_EATER_STATS    lizard 5 55}
+        {UNIT_BODY_BRAIN_EATER_GRAPHICS brain-saurian}
     [/variation]
+
     [variation]
         variation_id=swimmer
         variation_name= _ "wc_variation^Swimmer"
-        {UNIT_BODY_BRAINEATER_STATS swimmer 5 58}
-        {UNIT_BODY_BRAINEATER_GRAPHICS brain-swimmer}
+        inherit=yes
+        profile=unit_image
+        {UNIT_BODY_BRAIN_EATER_STATS    swimmer 5 58}
+        {UNIT_BODY_BRAIN_EATER_GRAPHICS brain-swimmer}
         [movement_costs]
             forest=4
             hills=4
+            deep_water=1
         [/movement_costs]
+        [defense]
+            deep_water=50
+        [/defense]
     [/variation]
+
     [variation]
         variation_id=troll
         variation_name= _ "wc_variation^Troll"
-        {UNIT_BODY_BRAINEATER_STATS largefoot 5 63}
-        {UNIT_BODY_BRAINEATER_GRAPHICS brain-troll}
-        [movement_costs]
-            deep_water=4
-        [/movement_costs]
-        [defense]
-            deep_water=90
-        [/defense]
+        inherit=yes
+        profile=unit_image
+        {UNIT_BODY_BRAIN_EATER_STATS    largefoot 5 63}
+        {UNIT_BODY_BRAIN_EATER_GRAPHICS brain-troll}
     [/variation]
+
     [variation]
         variation_id=wose
         variation_name= _ "wc_variation^Wose"
-        {UNIT_BODY_BRAINEATER_STATS treefolk 4 70}
-        {UNIT_BODY_BRAINEATER_GRAPHICS brain-wose}
-        [movement_costs]
-            deep_water=3
-        [/movement_costs]
-        [defense]
-            deep_water=90
-        [/defense]
+        inherit=yes
+        profile=unit_image
+        {UNIT_BODY_BRAIN_EATER_STATS    treefolk 4 70}
+        {UNIT_BODY_BRAIN_EATER_GRAPHICS brain-wose}
     [/variation]
+
+    #[variation]
+    #    variation_id=wolf
+    #    variation_name= _ "wc_variation^Wolf"
+    #    inherit=yes
+    #    profile=unit_image
+    #    {UNIT_BODY_BRAIN_EATER_STATS orcishfoot X XX}
+    #    {UNIT_BODY_BRAIN_EATER_GRAPHICS soulless-wolf}
+    #    [defense]
+    #        village=50
+    #    [/defense]
+    #[/variation]
+
     [variation]
         variation_id=bat
         variation_name= _ "wc_variation^Bat"
-        inherit=no
-        {UNIT_BODY_BRAINEATER_STATS fly 6 54}
+        inherit=yes
+        profile=unit_image
+        {UNIT_BODY_BRAIN_EATER_STATS fly 6 54}
+        {UNIT_BODY_BRAIN_EATER_DEATH brain-bat}
+        image="units/brain/brain-bat-se-3.png"
+        die_sound="bat-flapping.wav"
         [movement_costs]
             cave=1
             fungus=1
+            deep_water=1
         [/movement_costs]
         [defense]
             cave=50
             fungus=50
+            deep_water=50
         [/defense]
         [resistance]
             cold=70
         [/resistance]
-        {MAGENTA_IS_THE_TEAM_COLOR}
-        image="units/brain/brain-bat-se-3.png"
-        die_sound="bat-flapping.wav"
         [defend]
             direction=s,sw,se
             [if]
@@ -318,32 +275,9 @@
             [/if]
             start_time=-126
             [frame]
-                duration=1
-                image="units/brain/brain-bat-se-3.png"
+                image="units/brain/brain-bat-se-[3,4,3].png:[1,250,1]"
             [/frame]
-            [frame]
-                duration=100
-                image="units/brain/brain-bat-se-4.png"
-            [/frame]
-            [if]
-                hits=hit
-                [frame]
-                    duration=150
-                    image="units/brain/brain-bat-se-4.png"
-                    sound={SOUND_LIST:ZOMBIE_WEAK_HIT}
-                [/frame]
-            [/if]
-            [else]
-                hits=miss,kill
-                [frame]
-                    duration=150
-                    image="units/brain/brain-bat-se-4.png"
-                [/frame]
-            [/else]
-            [frame]
-                duration=1
-                image="units/brain/brain-bat-se-3.png"
-            [/frame]
+            {SOUND:HIT {SOUND_LIST:ZOMBIE_WEAK_HIT} -25}
         [/defend]
         [defend]
             direction=n,nw,ne
@@ -353,103 +287,22 @@
             [/if]
             start_time=-126
             [frame]
-                duration=1
-                image="units/brain/brain-bat-ne-3.png"
+                image="units/brain/brain-bat-ne-[3,4,3].png:[1,250,1]"
             [/frame]
-            [frame]
-                duration=100
-                image="units/brain/brain-bat-ne-4.png"
-            [/frame]
-            [if]
-                hits=hit
-                [frame]
-                    duration=150
-                    image="units/brain/brain-bat-ne-4.png"
-                    sound={SOUND_LIST:ZOMBIE_WEAK_HIT}
-                [/frame]
-            [/if]
-            [else]
-                hits=miss,kill
-                [frame]
-                    duration=150
-                    image="units/brain/brain-bat-ne-4.png"
-                [/frame]
-            [/else]
-            [frame]
-                duration=1
-                image="units/brain/brain-bat-ne-3.png"
-            [/frame]
+            {SOUND:HIT {SOUND_LIST:ZOMBIE_WEAK_HIT} -25}
         [/defend]
         [standing_anim]
             direction=s,se,sw
             start_time=0
             [frame]
-                duration=50
-                image="units/brain/brain-bat-se-3.png"
-            [/frame]
-            [frame]
-                duration=60
-                image="units/brain/brain-bat-se-2.png"
-            [/frame]
-            [frame]
-                duration=80
-                image="units/brain/brain-bat-se-1.png"
-            [/frame]
-            [frame]
-                duration=60
-                image="units/brain/brain-bat-se-2.png"
-            [/frame]
-            [frame]
-                duration=50
-                image="units/brain/brain-bat-se-3.png"
-            [/frame]
-            [frame]
-                duration=60
-                image="units/brain/brain-bat-se-4.png"
-            [/frame]
-            [frame]
-                duration=80
-                image="units/brain/brain-bat-se-5.png"
-            [/frame]
-            [frame]
-                duration=60
-                image="units/brain/brain-bat-se-4.png"
+                image="units/brain/brain-bat-se-[3~1,2~5,4].png:[50,60,80,60,50,60,80,60]"
             [/frame]
         [/standing_anim]
         [standing_anim]
             direction=n,ne,nw
             start_time=0
             [frame]
-                duration=50
-                image="units/brain/brain-bat-ne-3.png"
-            [/frame]
-            [frame]
-                duration=60
-                image="units/brain/brain-bat-ne-2.png"
-            [/frame]
-            [frame]
-                duration=80
-                image="units/brain/brain-bat-ne-1.png"
-            [/frame]
-            [frame]
-                duration=60
-                image="units/brain/brain-bat-ne-2.png"
-            [/frame]
-            [frame]
-                duration=50
-                image="units/brain/brain-bat-ne-3.png"
-            [/frame]
-            [frame]
-                duration=60
-                image="units/brain/brain-bat-ne-4.png"
-            [/frame]
-            [frame]
-                duration=80
-                image="units/brain/brain-bat-ne-5.png"
-            [/frame]
-            [frame]
-                duration=60
-                image="units/brain/brain-bat-ne-4.png"
+                image="units/brain/brain-bat-ne-[3~1,2~5,4].png:[50,60,80,60,50,60,80,60]"
             [/frame]
         [/standing_anim]
 
@@ -461,42 +314,21 @@
             offset=0.0~0.9:200,0.9~0.0:160
             start_time=-200
             [frame]
-                duration=30
-                image="units/brain/brain-bat-se-3.png"
+                image="units/brain/brain-bat-se-[3,2].png:30"
             [/frame]
             [frame]
-                duration=30
-                image="units/brain/brain-bat-se-2.png"
-            [/frame]
-            [frame]
-                duration=30
-                image="units/brain/brain-bat-se-1.png"
+                image="units/brain/brain-bat-se-1.png:30"
                 sound=bat-flapping.wav
             [/frame]
             [frame]
-                duration=30
-                image="units/brain/brain-bat-se-2.png"
+                image="units/brain/brain-bat-se-[2,3].png:30"
             [/frame]
             [frame]
-                duration=30
-                image="units/brain/brain-bat-se-3.png"
-            [/frame]
-            [frame]
-                duration=70
-                image="units/brain/brain-bat-se-4.png"
+                image="units/brain/brain-bat-se-4.png:70"
                 sound=zombie-attack.wav
             [/frame]
             [frame]
-                duration=50
-                image="units/brain/brain-bat-se-3.png"
-            [/frame]
-            [frame]
-                duration=50
-                image="units/brain/brain-bat-se-2.png"
-            [/frame]
-            [frame]
-                duration=40
-                image="units/brain/brain-bat-se-3.png"
+                image="units/brain/brain-bat-se-[3,2,3].png:[50*2,40]"
             [/frame]
         [/attack_anim]
 
@@ -508,87 +340,27 @@
             offset=0.0~0.9:200,0.9~0.0:160
             start_time=-200
             [frame]
-                duration=30
-                image="units/brain/brain-bat-ne-3.png"
+                image="units/brain/brain-bat-ne-[3,2].png:30"
             [/frame]
             [frame]
-                duration=30
-                image="units/brain/brain-bat-ne-2.png"
-            [/frame]
-            [frame]
-                duration=30
-                image="units/brain/brain-bat-ne-1.png"
+                image="units/brain/brain-bat-ne-1.png:30"
                 sound=bat-flapping.wav
             [/frame]
             [frame]
-                duration=30
-                image="units/brain/brain-bat-ne-2.png"
+                image="units/brain/brain-bat-ne-[2,3].png:30"
             [/frame]
             [frame]
-                duration=30
-                image="units/brain/brain-bat-ne-3.png"
-            [/frame]
-            [frame]
-                duration=70
-                image="units/brain/brain-bat-ne-4.png"
+                image="units/brain/brain-bat-ne-4.png:70"
                 sound=zombie-attack.wav
             [/frame]
             [frame]
-                duration=50
-                image="units/brain/brain-bat-ne-3.png"
-            [/frame]
-            [frame]
-                duration=50
-                image="units/brain/brain-bat-ne-2.png"
-            [/frame]
-            [frame]
-                duration=40
-                image="units/brain/brain-bat-ne-3.png"
+                image="units/brain/brain-bat-ne-[3,2,3].png:[50*2,40]"
             [/frame]
         [/attack_anim]
-        [death]
-            start_time=0
-            [frame]
-                duration=150
-                image="units/brain/brain-bat-die-1.png"
-            [/frame]
-            [frame]
-                duration=150
-                image="units/brain/brain-bat-die-2.png"
-            [/frame]
-            [frame]
-                duration=150
-                image="units/brain/brain-bat-die-3.png"
-            [/frame]
-            [frame]
-                duration=150
-                image="units/brain/brain-bat-die-4.png"
-            [/frame]
-            [frame]
-                duration=150
-                image="units/brain/brain-die-5.png"
-            [/frame]
-            [frame]
-                duration=150
-                image="units/brain/brain-die-6.png"
-            [/frame]
-            [frame]
-                duration=150
-                image="units/brain/brain-die-7.png"
-            [/frame]
-            [frame]
-                duration=150
-                image="units/brain/brain-die-8.png"
-            [/frame]
-            [frame]
-                duration=150
-                image="units/brain/brain-die-9.png"
-            [/frame]
-            [frame]
-                duration=150
-                image="units/brain/brain-die-10.png"
-            [/frame]
-        [/death]
     [/variation]
-    #textdomain wesnoth-Danse_Macabre
 [/unit_type]
+
+#undef UNIT_BODY_BRAIN_EATER_STATS
+#undef UNIT_BODY_BRAIN_EATER_GRAPHICS
+#undef UNIT_BODY_BRAIN_EATER_ANIMATIONS
+#undef UNIT_BODY_BRAIN_EATER_DEATH

--- a/units/a4_Battalion.cfg
+++ b/units/a4_Battalion.cfg
@@ -1,14 +1,79 @@
 #textdomain wesnoth-Danse_Macabre
+
+# Variant HP, MP, and MP types for the Battalion
+#define UNIT_BODY_BATTALION_STATS MOVETYPE_ID MOVES_NUMBER HP_AMOUNT
+    hitpoints={HP_AMOUNT}
+    movement_type={MOVETYPE_ID}
+    movement={MOVES_NUMBER}
+#enddef
+
+# The death animation is different compared to mainline
+#define UNIT_BODY_BATTALION_DEATH BASE_NAME
+    [death]
+        start_time=0
+        [frame]
+            image="units/battalion/{BASE_NAME}-die-[1~2].png:150"
+        [/frame]
+        [frame]
+            image="units/undead/{BASE_NAME}-die-[3~4].png:150"
+        [/frame]
+        [frame]
+            image="units/undead/soulless-die-[5~10].png:150"
+        [/frame]
+    [/death]
+#enddef
+
+# This is the same like in mainline - without dead animation, because drake/gryphons use a different one
+#define UNIT_BODY_BATTALION_ANIMATIONS BASE_NAME
+    image="units/battalion/{BASE_NAME}.png"
+    {DEFENSE_ANIM "units/battalion/{BASE_NAME}-defend.png" "units/battalion/{BASE_NAME}.png" {SOUND_LIST:ZOMBIE_HIT} }
+    [attack_anim]
+        [filter_attack]
+            name=touch
+        [/filter_attack]
+        direction=s
+        start_time=-200
+        [frame]
+            image="units/battalion/{BASE_NAME}-attack-s.png:400"
+            sound=zombie-attack.wav
+        [/frame]
+    [/attack_anim]
+    [attack_anim]
+        [filter_attack]
+            name=touch
+        [/filter_attack]
+        direction=n
+        start_time=-200
+        [frame]
+            image="units/battalion/{BASE_NAME}-attack-n.png:400"
+            sound=zombie-attack.wav
+        [/frame]
+    [/attack_anim]
+    [attack_anim]
+        [filter_attack]
+            name=touch
+        [/filter_attack]
+        direction=se,sw,ne,nw
+        start_time=-200
+        [frame]
+            image="units/battalion/{BASE_NAME}-attack.png:400"
+            sound=zombie-attack.wav
+        [/frame]
+    [/attack_anim]
+#enddef
+
+# both macros together are like the mainline one
+#define UNIT_BODY_BATTALION_GRAPHICS BASE_NAME
+    {UNIT_BODY_BATTALION_ANIMATIONS {BASE_NAME}}
+    {UNIT_BODY_BATTALION_DEATH {BASE_NAME}}
+#enddef
+
 [unit_type]
-    #macro to define most of the non-graphical part of Walking Corpse
-#define UNIT_BODY_BATTALION_STATS MOVETYPE MOVES HP
     id=Battalion
     name= _ "Battalion"
+    profile=portraits/undead/soulless.png
     race=undead
     {TRAIT_FEARLESS_MUSTHAVE}
-    hitpoints={HP}
-    movement_type={MOVETYPE}
-    movement={MOVES}
     experience=150
     level=4
     alignment=chaotic
@@ -17,9 +82,9 @@
     cost=43
     usage=fighter
     description= _ "How on the earth has this one been entertained? It is not a product of necromancy, but unexpected disaster. Without horses, we couldn't escape from this disaster. Even solid armor can be blown sky-high. For this very reason, they are called Battalion and feared by everyone."+{SPECIAL_NOTES}+{SPECIAL_NOTES_PLAGUE}
-    [resistance]
-        arcane=140
-    [/resistance]
+    die_sound={SOUND_LIST:ZOMBIE_HIT}
+    {MAGENTA_IS_THE_TEAM_COLOR}
+
     [attack]
         name=touch
         description={STR_TOUCH}
@@ -32,285 +97,177 @@
             {WEAPON_SPECIAL_PLAGUE}
         [/specials]
     [/attack]
-#enddef
-    #macro to define most of the graphical part of Walking Corpse
-#define UNIT_BODY_BATTALION_GRAPHICS_NO_DEATH_ANIM BASE_IMAGESTEM
-    image="units/battalion/{BASE_IMAGESTEM}.png"
-    {MAGENTA_IS_THE_TEAM_COLOR}
-    die_sound={SOUND_LIST:ZOMBIE_HIT}
-    {DEFENSE_ANIM "units/battalion/{BASE_IMAGESTEM}-defend.png" "units/battalion/{BASE_IMAGESTEM}.png" {SOUND_LIST:ZOMBIE_HIT} }
-    [death]
-        start_time=0
-        [frame]
-            duration=150
-            image="units/battalion/battalion-die-4.png"
-        [/frame]
-        [frame]
-            duration=150
-            image="units/battalion/battalion-die-5.png"
-        [/frame]
-        [frame]
-            duration=150
-            image="units/battalion/battalion-die-6.png"
-        [/frame]
-        [frame]
-            duration=150
-            image="units/battalion/battalion-die-7.png"
-        [/frame]
-        [frame]
-            duration=150
-            image="units/battalion/battalion-die-8.png"
-        [/frame]
-        [frame]
-            duration=150
-            image="units/battalion/battalion-die-9.png"
-        [/frame]
-        [frame]
-            duration=150
-            image="units/battalion/battalion-die-10.png"
-        [/frame]
-    [/death]
-    [attack_anim]
-        [filter_attack]
-            name=touch
-        [/filter_attack]
-        direction=s
-        [frame]
-            begin=-200
-            end=200
-            image="units/battalion/{BASE_IMAGESTEM}-attack-s.png"
-            sound=zombie-attack.wav
-        [/frame]
-    [/attack_anim]
-    [attack_anim]
-        [filter_attack]
-            name=touch
-        [/filter_attack]
-        direction=n
-        [frame]
-            begin=-200
-            end=200
-            image="units/battalion/{BASE_IMAGESTEM}-attack-n.png"
-            sound=zombie-attack.wav
-        [/frame]
-    [/attack_anim]
-    [attack_anim]
-        [filter_attack]
-            name=touch
-        [/filter_attack]
-        direction=se,sw,ne,nw
-        [frame]
-            begin=-200
-            end=200
-            image="units/battalion/{BASE_IMAGESTEM}-attack.png"
-            sound=zombie-attack.wav
-        [/frame]
-    [/attack_anim]
-#enddef
-#define UNIT_BODY_BATTALION_GRAPHICS BASE_IMAGESTEM
-    image="units/battalion/{BASE_IMAGESTEM}.png"
-    {MAGENTA_IS_THE_TEAM_COLOR}
-    die_sound={SOUND_LIST:ZOMBIE_HIT}
-    {DEFENSE_ANIM "units/battalion/{BASE_IMAGESTEM}-defend.png" "units/battalion/{BASE_IMAGESTEM}.png" {SOUND_LIST:ZOMBIE_HIT} }
-    [death]
-        start_time=0
-        [frame]
-            duration=150
-            image="units/battalion/{BASE_IMAGESTEM}-die-1.png"
-        [/frame]
-        [frame]
-            duration=150
-            image="units/battalion/{BASE_IMAGESTEM}-die-2.png"
-        [/frame]
-        [frame]
-            duration=150
-            image="units/battalion/{BASE_IMAGESTEM}-die-3.png"
-        [/frame]
-        [frame]
-            duration=150
-            image="units/battalion/{BASE_IMAGESTEM}-die-4.png"
-        [/frame]
-        [frame]
-            duration=150
-            image="units/battalion/battalion-die-5.png"
-        [/frame]
-        [frame]
-            duration=150
-            image="units/battalion/battalion-die-6.png"
-        [/frame]
-        [frame]
-            duration=150
-            image="units/battalion/battalion-die-7.png"
-        [/frame]
-        [frame]
-            duration=150
-            image="units/battalion/battalion-die-8.png"
-        [/frame]
-        [frame]
-            duration=150
-            image="units/battalion/battalion-die-9.png"
-        [/frame]
-        [frame]
-            duration=150
-            image="units/battalion/battalion-die-10.png"
-        [/frame]
-    [/death]
-    [attack_anim]
-        [filter_attack]
-            name=touch
-        [/filter_attack]
-        direction=s
-        [frame]
-            begin=-200
-            end=200
-            image="units/battalion/{BASE_IMAGESTEM}-attack-s.png"
-            sound=zombie-attack.wav
-        [/frame]
-    [/attack_anim]
-    [attack_anim]
-        [filter_attack]
-            name=touch
-        [/filter_attack]
-        direction=n
-        [frame]
-            begin=-200
-            end=200
-            image="units/battalion/{BASE_IMAGESTEM}-attack-n.png"
-            sound=zombie-attack.wav
-        [/frame]
-    [/attack_anim]
-    [attack_anim]
-        [filter_attack]
-            name=touch
-        [/filter_attack]
-        direction=se,sw,ne,nw
-        [frame]
-            begin=-200
-            end=200
-            image="units/battalion/{BASE_IMAGESTEM}-attack.png"
-            sound=zombie-attack.wav
-        [/frame]
-    [/attack_anim]
-#enddef
-    {UNIT_BODY_BATTALION_STATS smallfoot 7 78}
-    {UNIT_BODY_BATTALION_GRAPHICS battalion}
+
+    [resistance]
+        arcane=140
+    [/resistance]
     [movement_costs]
         deep_water=4
     [/movement_costs]
     [defense]
         deep_water=90
     [/defense]
+
+    {UNIT_BODY_BATTALION_STATS    smallfoot 7 78}
+    {UNIT_BODY_BATTALION_GRAPHICS battalion}
+
     #textdomain wesnoth-units
     [variation]
         variation_id=drake
         variation_name= _ "wc_variation^Drake"
-        {UNIT_BODY_BATTALION_STATS drakefoot 7 86}
-        {UNIT_BODY_BATTALION_GRAPHICS_NO_DEATH_ANIM battalion-drake}
+        inherit=yes
+        profile=unit_image
+        {UNIT_BODY_BATTALION_STATS      drakefoot 7 86}
+        {UNIT_BODY_BATTALION_ANIMATIONS battalion-drake}
         [movement_costs]
-            deep_water=4
+            unwalkable=4
         [/movement_costs]
         [defense]
-            deep_water=90
+            unwalkable=90
         [/defense]
+        [death]
+            start_time=0
+            [frame]
+                image="units/battalion/battalion-drake-die-[1~3].png:150"
+            [/frame]
+            [frame]
+                image="units/battalion/battalion-drake-die-3.png:600"
+                alpha=1~0
+            [/frame]
+        [/death]
     [/variation]
+
     [variation]
         variation_id=dwarf
         variation_name= _ "wc_variation^Dwarf"
-        {UNIT_BODY_BATTALION_STATS dwarvishfoot 6 83}
+        inherit=yes
+        profile=unit_image
+        {UNIT_BODY_BATTALION_STATS    dwarvishfoot 6 83}
         {UNIT_BODY_BATTALION_GRAPHICS battalion-dwarf}
-        [movement_costs]
-            deep_water=3
-        [/movement_costs]
-        [defense]
-            deep_water=90
-        [/defense]
     [/variation]
+
+    #[variation]
+    #    variation_id=goblin
+    #    variation_name= _ "wc_variation^Goblin"
+    #    inherit=yes
+    #    profile=unit_image
+    #    {UNIT_BODY_BATTALION_STATS    smallfoot X XX}
+    #    {UNIT_BODY_BATTALION_GRAPHICS soulless-goblin}
+    #[/variation]
+
     [variation]
         variation_id=mounted
         variation_name= _ "wc_variation^Mounted"
-        {UNIT_BODY_BATTALION_STATS mounted 8 83}
+        inherit=yes
+        # Default portrait is fine for Mounted
+        {UNIT_BODY_BATTALION_STATS    mounted 8 83}
         {UNIT_BODY_BATTALION_GRAPHICS battalion-mounted}
-        [movement_costs]
-            deep_water=4
-        [/movement_costs]
-        [defense]
-            deep_water=90
-        [/defense]
     [/variation]
+
     [variation]
         variation_id=gryphon
         variation_name= _ "wc_variation^Gryphon"
-        {UNIT_BODY_BATTALION_STATS fly 8 83}
-        {UNIT_BODY_BATTALION_GRAPHICS battalion-drake}
+        inherit=yes
+        profile=unit_image
+        {UNIT_BODY_BATTALION_STATS      fly 8 83}
+        {UNIT_BODY_BATTALION_ANIMATIONS battalion-drake}
+        [movement_costs]
+            deep_water=1
+        [/movement_costs]
         [defense]
             mountains=40
+            deep_water=50
         [/defense]
+        [death]
+            start_time=0
+            [frame]
+                image="units/battalion/battalion-drake-die-[1~3].png:150"
+            [/frame]
+            [frame]
+                image="units/battalion/battalion-drake-die-3.png:600"
+                alpha=1~0
+            [/frame]
+        [/death]
     [/variation]
+
     [variation]
         variation_id=saurian
         variation_name= _ "wc_variation^Saurian"
-        {UNIT_BODY_BATTALION_STATS lizard 7 75}
+        inherit=yes
+        profile=unit_image
+        {UNIT_BODY_BATTALION_STATS    lizard 7 75}
         {UNIT_BODY_BATTALION_GRAPHICS battalion-saurian}
-        [movement_costs]
-            deep_water=4
-        [/movement_costs]
-        [defense]
-            deep_water=90
-        [/defense]
     [/variation]
+
     [variation]
         variation_id=swimmer
         variation_name= _ "wc_variation^Swimmer"
-        {UNIT_BODY_BATTALION_STATS swimmer 7 78}
+        inherit=yes
+        profile=unit_image
+        {UNIT_BODY_BATTALION_STATS    swimmer 7 78}
         {UNIT_BODY_BATTALION_GRAPHICS battalion-swimmer}
         [movement_costs]
             forest=4
             hills=4
+            deep_water=1
         [/movement_costs]
+        [defense]
+            deep_water=50
+        [/defense]
     [/variation]
+
     [variation]
         variation_id=troll
         variation_name= _ "wc_variation^Troll"
-        {UNIT_BODY_BATTALION_STATS largefoot 7 83}
+        inherit=yes
+        profile=unit_image
+        {UNIT_BODY_BATTALION_STATS    largefoot 7 83}
         {UNIT_BODY_BATTALION_GRAPHICS battalion-troll}
-        [movement_costs]
-            deep_water=4
-        [/movement_costs]
-        [defense]
-            deep_water=90
-        [/defense]
     [/variation]
+
     [variation]
         variation_id=wose
         variation_name= _ "wc_variation^Wose"
-        {UNIT_BODY_BATTALION_STATS treefolk 6 90}
+        inherit=yes
+        profile=unit_image
+        {UNIT_BODY_BATTALION_STATS    treefolk 6 90}
         {UNIT_BODY_BATTALION_GRAPHICS battalion-wose}
-        [movement_costs]
-            deep_water=3
-        [/movement_costs]
-        [defense]
-            deep_water=90
-        [/defense]
     [/variation]
+
+    #[variation]
+    #    variation_id=wolf
+    #    variation_name= _ "wc_variation^Wolf"
+    #    inherit=yes
+    #    profile=unit_image
+    #    {UNIT_BODY_BATTALION_STATS orcishfoot X XX}
+    #    {UNIT_BODY_BATTALION_GRAPHICS soulless-wolf}
+    #    [defense]
+    #        village=50
+    #    [/defense]
+    #[/variation]
+
     [variation]
         variation_id=bat
         variation_name= _ "wc_variation^Bat"
-        inherit=no
+        inherit=yes
+        profile=unit_image
         {UNIT_BODY_BATTALION_STATS fly 8 74}
+        {UNIT_BODY_BATTALION_DEATH battalion-bat}
+        image="units/battalion/battalion-bat-se-3.png"
+        die_sound="bat-flapping.wav"
         [movement_costs]
             cave=1
             fungus=1
+            deep_water=1
         [/movement_costs]
         [defense]
             cave=50
             fungus=50
+            deep_water=50
         [/defense]
         [resistance]
             cold=70
         [/resistance]
-        {MAGENTA_IS_THE_TEAM_COLOR}
-        image="units/battalion/battalion-bat-se-3.png"
-        die_sound="bat-flapping.wav"
         [defend]
             direction=s,sw,se
             [if]
@@ -319,32 +276,9 @@
             [/if]
             start_time=-126
             [frame]
-                duration=1
-                image="units/battalion/battalion-bat-se-3.png"
+                image="units/battalion/battalion-bat-se-[3,4,3].png:[1,250,1]"
             [/frame]
-            [frame]
-                duration=100
-                image="units/battalion/battalion-bat-se-4.png"
-            [/frame]
-            [if]
-                hits=hit
-                [frame]
-                    duration=150
-                    image="units/battalion/battalion-bat-se-4.png"
-                    sound={SOUND_LIST:ZOMBIE_WEAK_HIT}
-                [/frame]
-            [/if]
-            [else]
-                hits=miss,kill
-                [frame]
-                    duration=150
-                    image="units/battalion/battalion-bat-se-4.png"
-                [/frame]
-            [/else]
-            [frame]
-                duration=1
-                image="units/battalion/battalion-bat-se-3.png"
-            [/frame]
+            {SOUND:HIT {SOUND_LIST:ZOMBIE_WEAK_HIT} -25}
         [/defend]
         [defend]
             direction=n,nw,ne
@@ -354,103 +288,22 @@
             [/if]
             start_time=-126
             [frame]
-                duration=1
-                image="units/battalion/battalion-bat-ne-3.png"
+                image="units/battalion/battalion-bat-ne-[3,4,3].png:[1,250,1]"
             [/frame]
-            [frame]
-                duration=100
-                image="units/battalion/battalion-bat-ne-4.png"
-            [/frame]
-            [if]
-                hits=hit
-                [frame]
-                    duration=150
-                    image="units/battalion/battalion-bat-ne-4.png"
-                    sound={SOUND_LIST:ZOMBIE_WEAK_HIT}
-                [/frame]
-            [/if]
-            [else]
-                hits=miss,kill
-                [frame]
-                    duration=150
-                    image="units/battalion/battalion-bat-ne-4.png"
-                [/frame]
-            [/else]
-            [frame]
-                duration=1
-                image="units/battalion/battalion-bat-ne-3.png"
-            [/frame]
+            {SOUND:HIT {SOUND_LIST:ZOMBIE_WEAK_HIT} -25}
         [/defend]
         [standing_anim]
             direction=s,se,sw
             start_time=0
             [frame]
-                duration=50
-                image="units/battalion/battalion-bat-se-3.png"
-            [/frame]
-            [frame]
-                duration=60
-                image="units/battalion/battalion-bat-se-2.png"
-            [/frame]
-            [frame]
-                duration=80
-                image="units/battalion/battalion-bat-se-1.png"
-            [/frame]
-            [frame]
-                duration=60
-                image="units/battalion/battalion-bat-se-2.png"
-            [/frame]
-            [frame]
-                duration=50
-                image="units/battalion/battalion-bat-se-3.png"
-            [/frame]
-            [frame]
-                duration=60
-                image="units/battalion/battalion-bat-se-4.png"
-            [/frame]
-            [frame]
-                duration=80
-                image="units/battalion/battalion-bat-se-5.png"
-            [/frame]
-            [frame]
-                duration=60
-                image="units/battalion/battalion-bat-se-4.png"
+                image="units/battalion/battalion-bat-se-[3~1,2~5,4].png:[50,60,80,60,50,60,80,60]"
             [/frame]
         [/standing_anim]
         [standing_anim]
             direction=n,ne,nw
             start_time=0
             [frame]
-                duration=50
-                image="units/battalion/battalion-bat-ne-3.png"
-            [/frame]
-            [frame]
-                duration=60
-                image="units/battalion/battalion-bat-ne-2.png"
-            [/frame]
-            [frame]
-                duration=80
-                image="units/battalion/battalion-bat-ne-1.png"
-            [/frame]
-            [frame]
-                duration=60
-                image="units/battalion/battalion-bat-ne-2.png"
-            [/frame]
-            [frame]
-                duration=50
-                image="units/battalion/battalion-bat-ne-3.png"
-            [/frame]
-            [frame]
-                duration=60
-                image="units/battalion/battalion-bat-ne-4.png"
-            [/frame]
-            [frame]
-                duration=80
-                image="units/battalion/battalion-bat-ne-5.png"
-            [/frame]
-            [frame]
-                duration=60
-                image="units/battalion/battalion-bat-ne-4.png"
+                image="units/battalion/battalion-bat-ne-[3~1,2~5,4].png:[50,60,80,60,50,60,80,60]"
             [/frame]
         [/standing_anim]
 
@@ -462,42 +315,21 @@
             offset=0.0~0.9:200,0.9~0.0:160
             start_time=-200
             [frame]
-                duration=30
-                image="units/battalion/battalion-bat-se-3.png"
+                image="units/battalion/battalion-bat-se-[3,2].png:30"
             [/frame]
             [frame]
-                duration=30
-                image="units/battalion/battalion-bat-se-2.png"
-            [/frame]
-            [frame]
-                duration=30
-                image="units/battalion/battalion-bat-se-1.png"
+                image="units/battalion/battalion-bat-se-1.png:30"
                 sound=bat-flapping.wav
             [/frame]
             [frame]
-                duration=30
-                image="units/battalion/battalion-bat-se-2.png"
+                image="units/battalion/battalion-bat-se-[2,3].png:30"
             [/frame]
             [frame]
-                duration=30
-                image="units/battalion/battalion-bat-se-3.png"
-            [/frame]
-            [frame]
-                duration=70
-                image="units/battalion/battalion-bat-se-4.png"
+                image="units/battalion/battalion-bat-se-4.png:70"
                 sound=zombie-attack.wav
             [/frame]
             [frame]
-                duration=50
-                image="units/battalion/battalion-bat-se-3.png"
-            [/frame]
-            [frame]
-                duration=50
-                image="units/battalion/battalion-bat-se-2.png"
-            [/frame]
-            [frame]
-                duration=40
-                image="units/battalion/battalion-bat-se-3.png"
+                image="units/battalion/battalion-bat-se-[3,2,3].png:[50*2,40]"
             [/frame]
         [/attack_anim]
 
@@ -509,87 +341,27 @@
             offset=0.0~0.9:200,0.9~0.0:160
             start_time=-200
             [frame]
-                duration=30
-                image="units/battalion/battalion-bat-ne-3.png"
+                image="units/battalion/battalion-bat-ne-[3,2].png:30"
             [/frame]
             [frame]
-                duration=30
-                image="units/battalion/battalion-bat-ne-2.png"
-            [/frame]
-            [frame]
-                duration=30
-                image="units/battalion/battalion-bat-ne-1.png"
+                image="units/battalion/battalion-bat-ne-1.png:30"
                 sound=bat-flapping.wav
             [/frame]
             [frame]
-                duration=30
-                image="units/battalion/battalion-bat-ne-2.png"
+                image="units/battalion/battalion-bat-ne-[2,3].png:30"
             [/frame]
             [frame]
-                duration=30
-                image="units/battalion/battalion-bat-ne-3.png"
-            [/frame]
-            [frame]
-                duration=70
-                image="units/battalion/battalion-bat-ne-4.png"
+                image="units/battalion/battalion-bat-ne-4.png:70"
                 sound=zombie-attack.wav
             [/frame]
             [frame]
-                duration=50
-                image="units/battalion/battalion-bat-ne-3.png"
-            [/frame]
-            [frame]
-                duration=50
-                image="units/battalion/battalion-bat-ne-2.png"
-            [/frame]
-            [frame]
-                duration=40
-                image="units/battalion/battalion-bat-ne-3.png"
+                image="units/battalion/battalion-bat-ne-[3,2,3].png:[50*2,40]"
             [/frame]
         [/attack_anim]
-        [death]
-            start_time=0
-            [frame]
-                duration=150
-                image="units/battalion/battalion-bat-die-1.png"
-            [/frame]
-            [frame]
-                duration=150
-                image="units/battalion/battalion-bat-die-2.png"
-            [/frame]
-            [frame]
-                duration=150
-                image="units/battalion/battalion-bat-die-3.png"
-            [/frame]
-            [frame]
-                duration=150
-                image="units/battalion/battalion-bat-die-4.png"
-            [/frame]
-            [frame]
-                duration=150
-                image="units/battalion/battalion-die-5.png"
-            [/frame]
-            [frame]
-                duration=150
-                image="units/battalion/battalion-die-6.png"
-            [/frame]
-            [frame]
-                duration=150
-                image="units/battalion/battalion-die-7.png"
-            [/frame]
-            [frame]
-                duration=150
-                image="units/battalion/battalion-die-8.png"
-            [/frame]
-            [frame]
-                duration=150
-                image="units/battalion/battalion-die-9.png"
-            [/frame]
-            [frame]
-                duration=150
-                image="units/battalion/battalion-die-10.png"
-            [/frame]
-        [/death]
     [/variation]
-    #textdomain wesnoth-Danse_Macabre
 [/unit_type]
+
+#undef UNIT_BODY_BATTALION_STATS
+#undef UNIT_BODY_BATTALION_GRAPHICS
+#undef UNIT_BODY_BATTALION_ANIMATIONS
+#undef UNIT_BODY_BATTALION_DEATH


### PR DESCRIPTION
don't bother comparing all that - writing code is easier than reading it.
only ingame change: wose/dwarf need 4 moves on deep water too
and drake die animation is a bit different

Death images with a number higher than 2 are now used from mainline, with the drake being an exception.
Only merrin & neckfrill still rely on them.

Oh, and while doing that I found a bug with the mainline zombies, good thing.